### PR TITLE
feat: make product query configuration init public

### DIFF
--- a/Sources/Model/OFF/ProductConfiguration.swift
+++ b/Sources/Model/OFF/ProductConfiguration.swift
@@ -12,7 +12,7 @@ public struct ProductQueryConfiguration {
     var languages: [OpenFoodFactsLanguage]
     var fields: [ProductField]?
     
-    init(barcode: String,
+    public init(barcode: String,
          languages: [OpenFoodFactsLanguage] = [],
          country: OpenFoodFactsCountry? = nil,
          fields: [ProductField]? = nil) {

--- a/Sources/Model/OFF/ProductField.swift
+++ b/Sources/Model/OFF/ProductField.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ProductField: String {
+public enum ProductField: String {
     case barcode = "code"
     case name = "product_name"
     case nameInLanguages = "product_name_"

--- a/Sources/Model/OFF/ProductResponse.swift
+++ b/Sources/Model/OFF/ProductResponse.swift
@@ -10,31 +10,31 @@ import Foundation
 public struct ProductResponse: Decodable {
     
     /// Possible value for [status]: the operation failed.
-    static let statusFailure = "failure"
+    public static let statusFailure = "failure"
 
     /// Possible value for [status]: the operation succeeded with warnings.
-    static let statusWarning = "success_with_warnings"
+    public static let statusWarning = "success_with_warnings"
 
     /// Possible value for [status]: the operation succeeded.
-    static let statusSuccess = "success"
+    public static let statusSuccess = "success"
 
     /// Possible value for [result.id]: product found
-    static let resultProductFound = "product_found"
+    public static let resultProductFound = "product_found"
 
     /// Possible value for [result.id]: product not found
-    static let resultProductNotFound = "product_not_found"
+    public static let resultProductNotFound = "product_not_found"
     
-    let barcode: String?
-    let status: String?
-    let product: Product?
+    public let barcode: String?
+    public let status: String?
+    public let product: Product?
     
-    enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case barcode = "code"
         case status
         case product
     }
     
-    func hasProduct() -> Bool {
+    public func hasProduct() -> Bool {
         guard let status = self.status else { return false }
         return status == ProductResponse.resultProductFound || status == ProductResponse.statusSuccess || status == ProductResponse.statusWarning
     }


### PR DESCRIPTION
### What
- Turn ProductQueryConfiguration init public & no more internal.


### Fixes bug(s)
 <!-- #1, #2 and #3 (change by appropriate issues) -->
- ProductQueryConfiguration' initializer is inaccessible due to 'internal' protection level

### Part of 
