### PR TITLE
fix: make ProductQueryConfiguration initializer public

### DIFF
--- a/Sources/Model/OFF/ProductConfiguration.swift
+++ b/Sources/Model/OFF/ProductConfiguration.swift
@@ -12,10 +12,10 @@ public struct ProductQueryConfiguration {
     var languages: [OpenFoodFactsLanguage]
     var fields: [ProductField]?
     
-    init(barcode: String,
-         languages: [OpenFoodFactsLanguage] = [],
-         country: OpenFoodFactsCountry? = nil,
-         fields: [ProductField]? = nil) {
+    public init(barcode: String,
+                languages: [OpenFoodFactsLanguage] = [],
+                country: OpenFoodFactsCountry? = nil,
+                fields: [ProductField]? = nil) {
         self.barcode = barcode
         self.languages = languages
         self.fields = fields

--- a/Tests/OpenFoodFactsSDK-iosTests/ProductQueryConfigurationPublicInitTests.swift
+++ b/Tests/OpenFoodFactsSDK-iosTests/ProductQueryConfigurationPublicInitTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+import OpenFoodFactsSDK
+
+final class ProductQueryConfigurationPublicInitTests: XCTestCase {
+    func testPublicInitializerIsAccessible() {
+        _ = ProductQueryConfiguration(barcode: "3017620422003")
+    }
+}


### PR DESCRIPTION
## Summary
- make `ProductQueryConfiguration` initializer `public` so SDK consumers can construct a config from app code
- add a regression test that imports `OpenFoodFactsSDK` (without `@testable`) and instantiates `ProductQueryConfiguration`

Fixes #6.

## Validation
- `swift test`
  - fails in this environment with an existing platform/dependency constraint:
    - `OpenFoodFactsSDK` requires macOS 10.13
    - `BarcodeView` requires macOS 10.15
