### PR TITLE
feat: Add Sendable conformance to nutrient taxonomy types

### DIFF
--- a/Sources/Model/OFF/NutrientMeta.swift
+++ b/Sources/Model/OFF/NutrientMeta.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Unit: String {
+public enum Unit: String, Sendable {
     case g, kcal, kj
     case milliG = "mg", microG = "µg", percentVol = "% vol"
     case percent = "%", mmol = "mmol/l", l = "l", milliL = "ml"
@@ -40,7 +40,7 @@ public enum Unit: String {
     }
 }
 
-public struct UnitType: Codable {
+public struct UnitType: Codable, Sendable {
     var en: Unit
 
     enum CodingKeys: String, CodingKey {
@@ -68,7 +68,7 @@ public struct UnitType: Codable {
     }
 }
 
-public struct NutrientMeta: Codable {
+public struct NutrientMeta: Codable, Sendable {
     
     public var unit: UnitType? // make it optional
     public var name: [String: String]
@@ -94,7 +94,7 @@ public struct NutrientMeta: Codable {
     }
 }
 
-public struct NutrientMetadata: Codable {
+public struct NutrientMetadata: Codable, Sendable {
     public var nutrients: [String: NutrientMeta]?
     
     public init(from decoder: Decoder) throws {

--- a/Sources/Model/OFF/OrderedNutrients.swift
+++ b/Sources/Model/OFF/OrderedNutrients.swift
@@ -69,3 +69,46 @@ public class OrderedNutrient: ObservableObject, Codable, Equatable, Identifiable
         return "OrderedNutrient(id: \(id), name: \(name), important: \(important), displayInEditForm: \(displayInEditForm), currentUnit: \(currentUnit), value: \(value))"
     }
 }
+
+// MARK: - Sendable snapshot
+
+/// Immutable, `Sendable` projection of an `OrderedNutrient` for
+/// passing across actor boundaries (Swift 6 strict concurrency).
+/// `OrderedNutrient` itself can't be `Sendable` because it's an
+/// `ObservableObject` with `@Published` mutable state.
+public struct OrderedNutrientSnapshot: Codable, Equatable, Identifiable, Sendable {
+    public let id: String
+    public let name: String
+    public let important: Bool
+    public let displayInEditForm: Bool
+    public let subNutrients: [OrderedNutrientSnapshot]?
+
+    public init(id: String, name: String, important: Bool,
+                displayInEditForm: Bool, subNutrients: [OrderedNutrientSnapshot]? = nil) {
+        self.id = id
+        self.name = name
+        self.important = important
+        self.displayInEditForm = displayInEditForm
+        self.subNutrients = subNutrients
+    }
+}
+
+public extension OrderedNutrient {
+    /// Build a `Sendable` snapshot of this nutrient (and its subtree).
+    func snapshot() -> OrderedNutrientSnapshot {
+        OrderedNutrientSnapshot(
+            id: id,
+            name: name,
+            important: important,
+            displayInEditForm: displayInEditForm,
+            subNutrients: subNutrients?.map { $0.snapshot() }
+        )
+    }
+}
+
+public extension Array where Element: OrderedNutrient {
+    /// Convenience: snapshot a whole array.
+    func snapshots() -> [OrderedNutrientSnapshot] {
+        self.map { $0.snapshot() }
+    }
+}

--- a/Sources/Model/OFF/SendImage.swift
+++ b/Sources/Model/OFF/SendImage.swift
@@ -28,13 +28,13 @@ public enum ImageField: String, CaseIterable, Decodable {
 
 public struct SendImage {
     
-    var barcode: String
-    var image: UIImage
-    var imageField: ImageField
+    public var barcode: String
+    public var image: UIImage
+    public var imageField: ImageField
     
-    var imageUri: String?
+    public var imageUri: String?
     
-    init(barcode: String, imageField: ImageField = .front, image: UIImage, imageUri: String? = nil) {
+    public init(barcode: String, imageField: ImageField = .front, image: UIImage, imageUri: String? = nil) {
         self.barcode = barcode
         self.image = image
         self.imageField = imageField

--- a/Sources/Networking/OpenFoodAPIClient.swift
+++ b/Sources/Networking/OpenFoodAPIClient.swift
@@ -203,4 +203,13 @@ final public actor OpenFoodAPIClient {
             throw error
         }
     }
+
+    /// Sendable variant of `getOrderedNutrients()` that returns
+    /// snapshot value types so the result can safely cross an
+    /// actor boundary in Swift 6 strict concurrency.
+    public func getOrderedNutrientSnapshots() async throws -> [OrderedNutrientSnapshot] {
+        let nutrients = try await getOrderedNutrients()
+        return nutrients.snapshots()
+    }
+
 }


### PR DESCRIPTION
## Summary

- Mark `Unit`, `UnitType`, `NutrientMeta`, `NutrientMetadata` as `Sendable` (annotation-only — fields are already value types).
- Add `OrderedNutrientSnapshot: Sendable` as an immutable projection of `OrderedNutrient`, plus `.snapshot()` / `.snapshots()` convenience.

`OrderedNutrient` itself can't be `Sendable` because it's an `ObservableObject` with `@Published` mutable state. The snapshot type lets callers under Swift 6 strict concurrency safely return the taxonomy data across actor boundaries.

## Why

Without this, `OpenFoodAPIClient.getOrderedNutrients()` and `fetchNutrientsMetadata()` aren't usable from `@MainActor` SwiftUI code under Swift 6 — the compiler rejects the cross-actor return because the result types aren't `Sendable`. We hit this consuming the SDK from a privacy-first food-intelligence iOS app and fell back to hand-curated nutrition tables; this PR unblocks SDK usage for the same purpose.

## Test plan

- [ ] `swift build` clean (note: pre-existing unrelated platform-min conflict between the SDK's macOS 10.13 and BarcodeView's macOS 10.15 prevents a full SwiftPM build on this branch)
- [ ] Verify `getOrderedNutrients()` + `fetchNutrientsMetadata()` callable from a Swift 6 strict-concurrency consumer
- [ ] Confirm no behavioral change for existing in-package usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)